### PR TITLE
Enable build on centos v1.22

### DIFF
--- a/api/BUILD
+++ b/api/BUILD
@@ -253,7 +253,8 @@ proto_library(
         "//envoy/extensions/transport_sockets/s2a/v3:pkg",
         "//envoy/extensions/transport_sockets/starttls/v3:pkg",
         "//envoy/extensions/transport_sockets/tap/v3:pkg",
-        "//envoy/extensions/transport_sockets/tcp_stats/v3:pkg",
+        # tcp_stats cannot be compiled in rhel7 due to old linux headers (tcp.h).
+        # "//envoy/extensions/transport_sockets/tcp_stats/v3:pkg",
         "//envoy/extensions/transport_sockets/tls/v3:pkg",
         "//envoy/extensions/upstreams/http/generic/v3:pkg",
         "//envoy/extensions/upstreams/http/http/v3:pkg",

--- a/api/envoy/extensions/transport_sockets/tcp_stats/v3/tcp_stats.proto
+++ b/api/envoy/extensions/transport_sockets/tcp_stats/v3/tcp_stats.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 
-package envoy.extensions.transport_sockets.tcp_stats.v3;
+
+// tcp_stats cannot be compiled in rhel7 due to old linux headers (tcp.h).
+// package envoy.extensions.transport_sockets.tcp_stats.v3;
 
 import "envoy/config/core/v3/base.proto";
 
@@ -9,10 +11,12 @@ import "google/protobuf/duration.proto";
 import "udpa/annotations/status.proto";
 import "validate/validate.proto";
 
-option java_package = "io.envoyproxy.envoy.extensions.transport_sockets.tcp_stats.v3";
+// tcp_stats cannot be compiled in rhel7 due to old linux headers (tcp.h).
+// option java_package = "io.envoyproxy.envoy.extensions.transport_sockets.tcp_stats.v3";
 option java_outer_classname = "TcpStatsProto";
 option java_multiple_files = true;
-option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tcp_stats/v3;tcp_statsv3";
+// tcp_stats cannot be compiled in rhel7 due to old linux headers (tcp.h).
+// option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tcp_stats/v3;tcp_statsv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: TCP Stats Transport Socket wrapper]

--- a/api/versioning/BUILD
+++ b/api/versioning/BUILD
@@ -193,7 +193,8 @@ proto_library(
         "//envoy/extensions/transport_sockets/s2a/v3:pkg",
         "//envoy/extensions/transport_sockets/starttls/v3:pkg",
         "//envoy/extensions/transport_sockets/tap/v3:pkg",
-        "//envoy/extensions/transport_sockets/tcp_stats/v3:pkg",
+        # tcp_stats cannot be compiled in rhel7 due to old linux headers (tcp.h).
+        # "//envoy/extensions/transport_sockets/tcp_stats/v3:pkg",
         "//envoy/extensions/transport_sockets/tls/v3:pkg",
         "//envoy/extensions/upstreams/http/generic/v3:pkg",
         "//envoy/extensions/upstreams/http/http/v3:pkg",

--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -553,6 +553,7 @@ envoy_cmake(
     build_data = ["@com_github_facebook_zstd//:all"],
     cache_entries = {
         "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_INSTALL_LIBDIR": "lib",
         "ZSTD_BUILD_SHARED": "off",
         "ZSTD_BUILD_STATIC": "on",
     },

--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -269,6 +269,10 @@ envoy_cmake(
         "//bazel:windows_x86_64": ["libcurl.lib"],
         "//conditions:default": ["libcurl.a"],
     }),
+    env = {
+        "CXXFLAGS": "-fPIC",
+	"CFLAGS": "-fPIC",
+    },
     deps = [
         ":ares",
         ":nghttp2",

--- a/source/common/upstream/cds_api_helper.cc
+++ b/source/common/upstream/cds_api_helper.cc
@@ -23,7 +23,8 @@ CdsApiHelper::onConfigUpdate(const std::vector<Config::DecodedResourceRef>& adde
     const auto eds_type_url =
         Config::getTypeUrl<envoy::config::endpoint::v3::ClusterLoadAssignment>();
     const auto leds_type_url = Config::getTypeUrl<envoy::config::endpoint::v3::LbEndpoint>();
-    maybe_resume_eds_leds = cm_.adsMux()->pause({eds_type_url, leds_type_url});
+    std::vector<std::string> url_types_list = {eds_type_url, leds_type_url};
+    maybe_resume_eds_leds = cm_.adsMux()->pause(url_types_list);
   }
 
   ENVOY_LOG(info, "{}: add {} cluster(s), remove {} cluster(s)", name_, added_resources.size(),

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -190,7 +190,8 @@ void ClusterManagerInitHelper::maybeFinishInitialize() {
         const auto eds_type_url =
             Config::getTypeUrl<envoy::config::endpoint::v3::ClusterLoadAssignment>();
         const auto leds_type_url = Config::getTypeUrl<envoy::config::endpoint::v3::LbEndpoint>();
-        maybe_resume_eds_leds = cm_.adsMux()->pause({eds_type_url, leds_type_url});
+        std::vector<std::string> url_types_list = {eds_type_url, leds_type_url};
+        maybe_resume_eds_leds = cm_.adsMux()->pause(url_types_list);
       }
       initializeSecondaryClusters();
     }

--- a/source/extensions/extensions_build_config.bzl
+++ b/source/extensions/extensions_build_config.bzl
@@ -208,7 +208,8 @@ EXTENSIONS = {
     "envoy.transport_sockets.raw_buffer":               "//source/extensions/transport_sockets/raw_buffer:config",
     "envoy.transport_sockets.tap":                      "//source/extensions/transport_sockets/tap:config",
     "envoy.transport_sockets.starttls":                 "//source/extensions/transport_sockets/starttls:config",
-    "envoy.transport_sockets.tcp_stats":                "//source/extensions/transport_sockets/tcp_stats:config",
+    # tcp_stats cannot be compiled in rhel7 due to old linux headers (tcp.h).
+    # "envoy.transport_sockets.tcp_stats":                "//source/extensions/transport_sockets/tcp_stats:config",
 
     #
     # Retry host predicates

--- a/source/extensions/extensions_metadata.yaml
+++ b/source/extensions/extensions_metadata.yaml
@@ -673,12 +673,13 @@ envoy.transport_sockets.tap:
   - envoy.transport_sockets.upstream
   security_posture: requires_trusted_downstream_and_upstream
   status: alpha
-envoy.transport_sockets.tcp_stats:
-  categories:
-  - envoy.transport_sockets.downstream
-  - envoy.transport_sockets.upstream
-  security_posture: robust_to_untrusted_downstream_and_upstream
-  status: alpha
+# tcp_stats cannot be compiled in rhel7 due to old linux headers (tcp.h).
+# envoy.transport_sockets.tcp_stats:
+#   categories:
+#   - envoy.transport_sockets.downstream
+#   - envoy.transport_sockets.upstream
+#   security_posture: robust_to_untrusted_downstream_and_upstream
+#   status: alpha
 envoy.transport_sockets.tls:
   categories:
   - envoy.transport_sockets.downstream

--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -75,7 +75,7 @@ JSON_STRING_TO_MESSAGE_ALLOWLIST = (
 # Histogram names which are allowed to be suffixed with the unit symbol, all of the pre-existing
 # ones were grandfathered as part of PR #8484 for backwards compatibility.
 HISTOGRAM_WITH_SI_SUFFIX_ALLOWLIST = (
-    "cx_rtt_us", "cx_rtt_variance_us", "downstream_cx_length_ms", "downstream_cx_length_ms",
+    "downstream_cx_length_ms", "downstream_cx_length_ms",
     "initialization_time_ms", "loop_duration_us", "poll_delay_us", "request_time_ms",
     "upstream_cx_connect_ms", "upstream_cx_length_ms")
 


### PR DESCRIPTION
Changes:
* Manually apply https://github.com/envoyproxy/envoy/pull/20918 to fix zstf failures
* Prevent building `tcp_stats` (new module of the last 2 versions that is failing to compile in rhel7, only used for stats so irrelevant to us)
* Proper definition of url types `std::vector` to prevent ambiguous overloading
* Addition of `-fPIC` flags to C and CXX in order to be able to compile in Ubuntu
