### PR TITLE
RED-140903 Do Not Dump Headers in stderr

### DIFF
--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -705,7 +705,8 @@ public:
        << DUMP_MEMBER(state_.observed_decode_end_stream_)
        << DUMP_MEMBER(state_.observed_encode_end_stream_) << "\n";
 
-    DUMP_DETAILS(filter_manager_callbacks_.requestHeaders());
+    // Disabled to avoid dumping sensitive information (such as AUTHORIZATION header)
+    // DUMP_DETAILS(filter_manager_callbacks_.requestHeaders());
     DUMP_DETAILS(filter_manager_callbacks_.requestTrailers());
     DUMP_DETAILS(filter_manager_callbacks_.responseHeaders());
     DUMP_DETAILS(filter_manager_callbacks_.responseTrailers());


### PR DESCRIPTION
When a function aborts, we see all headers in the envoy stderr. We have requested an enhancement https://github.com/envoyproxy/envoy/issues/37793, but until it is ready, we will patch the version.

